### PR TITLE
FIX click on HintPopover suggestions doesnt insert

### DIFF
--- a/src/js/base/module/HintPopover.js
+++ b/src/js/base/module/HintPopover.js
@@ -47,9 +47,9 @@ export default class HintPopover {
 
     this.$popover.hide();
     this.$content = this.$popover.find('.popover-content,.note-popover-content');
-    this.$content.on('click', '.note-hint-item', () => {
+    this.$content.on('click', '.note-hint-item', (e) => {
       this.$content.find('.active').removeClass('active');
-      $(this).addClass('active');
+      $(e.currentTarget).addClass('active');
       this.replace();
     });
   }


### PR DESCRIPTION
#### What does this PR do?

- FIX click on suggestions

#### Where should the reviewer start?
- start on the src/module/HintPopover.js

#### How should this be manually tested?

- Click on a hint suggestion

#### Any background context you want to provide?

- the gem needed to be updated...

#### What are the relevant tickets?
https://github.com/summernote/summernote/issues/2620

#### Screenshot (if for frontend)


### Checklist
- [ ] Create a new minor release soon
